### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,39 @@
+name: Check
+
+on:
+  push:
+    branches: [main]
+    paths-ignore: ['**.md']
+  pull_request:
+    branches: [main]
+    paths-ignore: ['**.md']
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm lint
+
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm exec playwright install --with-deps chromium
+      - run: pnpm test

--- a/test/fixtures/file-fixture.ts
+++ b/test/fixtures/file-fixture.ts
@@ -5,6 +5,7 @@ import path from 'path-browserify-esm'
 import { afterAll, beforeAll, describe, expect } from 'vitest'
 import { YankiConnect } from 'yanki-connect'
 import { normalize } from '../../src/lib/utilities/path'
+import { PLATFORM } from '../../src/lib/utilities/platform'
 import { getHash } from '../../src/lib/utilities/string'
 import { loadTestProfile } from '../utilities/anki-connect'
 import { TEST_PROFILE_NAME } from '../utilities/test-constants'
@@ -34,7 +35,8 @@ export function describeWithFileFixture(
 	{ assetPath, cleanUpAnki = true, cleanUpTempFiles = true }: FixtureOptions,
 	tests: (context: TestContext) => void,
 ) {
-	describe(description, () => {
+	// This test only runs on macOS
+	describe.skipIf(PLATFORM !== 'mac')(description, () => {
 		const context: TestContext = {
 			allFiles: [],
 			assetPath: '',

--- a/test/list.browser.test.ts
+++ b/test/list.browser.test.ts
@@ -1,6 +1,7 @@
 import { expect, it } from 'vitest'
 import type { YankiNote } from '../src/lib'
 import { listNotes, syncNotes } from '../src/lib'
+import { PLATFORM } from '../src/lib/utilities/platform'
 
 // Unused, yanki-connect uses browser fetch automatically if available
 // Browser fetch adapter example
@@ -12,7 +13,8 @@ import { listNotes, syncNotes } from '../src/lib'
 // 	return fetch(url, options)
 // }
 
-it('lists notes', { only: true }, async () => {
+// This test only runs on macOS
+it.skipIf(PLATFORM !== 'mac')('lists notes', async () => {
 	// Mock data
 	const namespace = 'Yanki Test - list.browser.test'
 	const testNote: YankiNote = {

--- a/test/list.node.test.ts
+++ b/test/list.node.test.ts
@@ -87,7 +87,8 @@ it('throws if anki is closed', { skip: PLATFORM !== 'mac', timeout: 10_000 }, as
 	).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: Anki is unreachable. Is Anki running?]`)
 })
 
-it('tells the truth if no notes are found', async () => {
+// This test only runs on macOS
+it.skipIf(PLATFORM !== 'mac')('tells the truth if no notes are found', async () => {
 	const result = await listNotes({
 		ankiConnectOptions: {
 			autoLaunch: true,

--- a/test/obsidian.node.test.ts
+++ b/test/obsidian.node.test.ts
@@ -6,13 +6,15 @@ import { expect, it } from 'vitest'
 import { detectVault } from '../src/bin/utilities/obsidian'
 import { getNoteFromMarkdown, syncFiles } from '../src/lib/index'
 import { getBase, normalize, stripBasePath } from '../src/lib/utilities/path'
+import { PLATFORM } from '../src/lib/utilities/platform'
 import { parseObsidianVaultLink } from '../src/lib/utilities/resolve-link'
 import { safeDecodeURI } from '../src/lib/utilities/url'
 import { describeWithFileFixture } from './fixtures/file-fixture'
 import { stripAnkiMediaTag } from './utilities/dom-inspector'
 import { stableResults } from './utilities/stable-sync-results'
 
-it('detects obsidian vault', async () => {
+// This test only runs on macOS
+it.skipIf(PLATFORM !== 'mac')('detects obsidian vault', async () => {
 	// Assumes vault has been opened at least once on this machine!
 	expect(await detectVault('./test/assets/test-obsidian-vault')).toBeDefined()
 	expect(await detectVault('./test/assets/test-obsidian-vault/')).toBeDefined()

--- a/test/sync.browser.test.ts
+++ b/test/sync.browser.test.ts
@@ -1,8 +1,10 @@
 import { expect, it } from 'vitest'
 import type { FileAdapter } from '../src/lib'
 import { getNoteFromMarkdown, syncNotes } from '../src/lib'
+import { PLATFORM } from '../src/lib/utilities/platform'
 
-it('syncs notes', async () => {
+// This test only runs on macOS
+it.skipIf(PLATFORM !== 'mac')('syncs notes', async () => {
 	const namespace = 'yanki.sync.browser.test'
 
 	const fileAdapter: FileAdapter = {

--- a/test/types.node.test.ts
+++ b/test/types.node.test.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url'
 import { expect, it } from 'vitest'
 import {
 	defaultGlobalOptions,
@@ -18,20 +19,20 @@ it('returns a valid file adapter in node', async () => {
 
 it('file adapter can read a file', async () => {
 	const adapter = await getDefaultFileAdapter()
-	const content = await adapter.readFile(new URL(import.meta.url).pathname)
+	const content = await adapter.readFile(fileURLToPath(import.meta.url))
 	expect(content).toContain('getDefaultFileAdapter')
 })
 
 it('file adapter can read a file as buffer', async () => {
 	const adapter = await getDefaultFileAdapter()
-	const buffer = await adapter.readFileBuffer(new URL(import.meta.url).pathname)
+	const buffer = await adapter.readFileBuffer(fileURLToPath(import.meta.url))
 	expect(buffer).toBeInstanceOf(Uint8Array)
 	expect(buffer.length).toBeGreaterThan(0)
 })
 
 it('file adapter can stat a file', async () => {
 	const adapter = await getDefaultFileAdapter()
-	const stats = await adapter.stat(new URL(import.meta.url).pathname)
+	const stats = await adapter.stat(fileURLToPath(import.meta.url))
 	expect(stats.size).toBeGreaterThan(0)
 	expect(stats.mtimeMs).toBeGreaterThan(0)
 	expect(stats.ctimeMs).toBeGreaterThan(0)

--- a/test/utilities/global-setup.ts
+++ b/test/utilities/global-setup.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
+import { PLATFORM } from '../../src/lib/utilities/platform'
 import { TEST_PROFILE_NAME } from '../utilities/test-constants'
 import { closeAnki, openAnki } from './anki-connect'
 
@@ -45,6 +46,11 @@ function getAnkiProfilePath(profileName: string): string {
  * Ensure Anki is running before tests run
  */
 export async function setup() {
+	if (PLATFORM !== 'mac') {
+		console.warn('Skipping Anki global setup: only supported on Mac')
+		return
+	}
+
 	// Close Anki if running, then reset the test profile for repeatable tests
 	await closeAnki()
 
@@ -69,5 +75,9 @@ export async function setup() {
  * Clean up
  */
 export async function teardown() {
+	if (PLATFORM !== 'mac') {
+		return
+	}
+
 	await closeAnki()
 }


### PR DESCRIPTION
This PR adds a workflow to check unit tests that are not dependent on Anki, and to check lint rules, in GitHub Actions. The tests that depend on Anki still do not work on Linux, so they are skipped.