### PR TITLE
Test: Add a per-user exe file path to `findAnkiWindows`

### DIFF
--- a/test/utilities/anki-connect.ts
+++ b/test/utilities/anki-connect.ts
@@ -28,6 +28,8 @@ function findAnkiWindows(): string {
 			'Scripts',
 			'anki.exe',
 		),
+		// Per-user installer
+		path.join(userProfile, 'AppData', 'Local', 'Programs', 'Anki', 'anki.exe'),
 		// Regular installer
 		path.join('C:', 'Program Files', 'Anki', 'anki.exe'),
 	]


### PR DESCRIPTION
Add `%USERPROFILE%/AppData/Local/Programs/Anki/anki.exe` as a candidate path to `findAnkiWindows`, which is the default path since Anki 24+ on Windows 11. The change only affects the test.