### PR TITLE
perf: skip Shiki parsing when no code blocks are present

### DIFF
--- a/src/lib/parse/parse.ts
+++ b/src/lib/parse/parse.ts
@@ -90,6 +90,10 @@ export async function getNoteFromMarkdown(
 	// Remove the frontmatter from the AST
 	ast = deleteFirstNodeOfType(ast, 'yaml')
 
+	// Quick check to skip rehypeShiki for notes without fenced code blocks,
+	// since Shiki has a significant performance cost even on plain text
+	const hasCodeBlocks = markdown.includes('```')
+
 	let front = ''
 	let back = ''
 	let extra: string | undefined
@@ -126,6 +130,7 @@ export async function getNoteFromMarkdown(
 				],
 				fetchAdapter,
 				fileAdapter,
+				hasCodeBlocks,
 				namespace: sanitizedNamespace,
 				strictLineBreaks,
 				syncMediaAssets,
@@ -140,6 +145,7 @@ export async function getNoteFromMarkdown(
 				],
 				fetchAdapter,
 				fileAdapter,
+				hasCodeBlocks,
 				namespace: sanitizedNamespace,
 				strictLineBreaks,
 				syncMediaAssets,
@@ -189,6 +195,7 @@ export async function getNoteFromMarkdown(
 				],
 				fetchAdapter,
 				fileAdapter,
+				hasCodeBlocks,
 				namespace: sanitizedNamespace,
 				strictLineBreaks,
 				syncMediaAssets,
@@ -205,6 +212,7 @@ export async function getNoteFromMarkdown(
 				],
 				fetchAdapter,
 				fileAdapter,
+				hasCodeBlocks,
 				namespace: sanitizedNamespace,
 				strictLineBreaks,
 				syncMediaAssets,
@@ -245,6 +253,7 @@ export async function getNoteFromMarkdown(
 				],
 				fetchAdapter,
 				fileAdapter,
+				hasCodeBlocks,
 				namespace: sanitizedNamespace,
 				strictLineBreaks,
 				syncMediaAssets,

--- a/src/lib/parse/rehype-utilities.ts
+++ b/src/lib/parse/rehype-utilities.ts
@@ -39,24 +39,24 @@ import remarkConditionalBreaks from './remark-conditional-breaks'
 const DIMENSION_CHARS_REGEX = /^[\dx]+$/
 
 // Significant performance improvement by reusing the processor
-const processor = unified()
-	.use(remarkConditionalBreaks)
-	// Not needed?
-	.use(remarkRehype, { allowDangerousHtml: true })
-	// Re-parses any raw HTML in the Markdown into the HAST tree,
-	// otherwise it ends up as text in raw-typed nodes. This allows
-	// things like manual <img> tags to be managed as Anki assets, and protects
-	// inline style tags from removal.
-	.use(rehypeRaw)
-	.use(rehypeMathjaxAnki)
-	//  Not needed?
-	// .use(rehypeRemoveComments)
-	// Messes up obsidian links and we should trust ourselves (and probably our plugins, too)
-	// .use(rehypeSanitize)
-	// Super slow...
-	// Other syntax highlighting Rehype plugins:
-	// https://github.com/Microflash/rehype-starry-night
-	// https://github.com/rehypejs/rehype-highlight
+function createBaseProcessor() {
+	return unified()
+		.use(remarkConditionalBreaks)
+		// Not needed?
+		.use(remarkRehype, { allowDangerousHtml: true })
+		// Re-parses any raw HTML in the Markdown into the HAST tree,
+		// otherwise it ends up as text in raw-typed nodes. This allows
+		// things like manual <img> tags to be managed as Anki assets, and protects
+		// inline style tags from removal.
+		.use(rehypeRaw)
+		.use(rehypeMathjaxAnki)
+}
+
+// Super slow...
+// Other syntax highlighting Rehype plugins:
+// https://github.com/Microflash/rehype-starry-night
+// https://github.com/rehypejs/rehype-highlight
+const processor = createBaseProcessor()
 	.use(rehypeShiki, {
 		// See https://shiki.style/packages/rehype
 		defaultLanguage: 'plaintext',
@@ -70,6 +70,10 @@ const processor = unified()
 	.use(rehypeFormat)
 	.use(rehypeStringify)
 
+const processorWithoutShiki = createBaseProcessor()
+	.use(rehypeFormat)
+	.use(rehypeStringify)
+
 type MdastToHtmlOptions = Simplify<
 	Pick<
 		GlobalOptions,
@@ -77,6 +81,8 @@ type MdastToHtmlOptions = Simplify<
 	> & {
 		/** CSS class names to apply to the output HTML */
 		cssClassNames?: string[]
+		/** Whether the source markdown contains fenced code blocks, enabling Shiki syntax highlighting */
+		hasCodeBlocks?: boolean
 		/** Whether to use an empty placeholder if the output is empty */
 		useEmptyPlaceholder?: boolean
 	}
@@ -98,6 +104,7 @@ export async function mdastToHtml(
 		cssClassNames,
 		fetchAdapter = getDefaultFetchAdapter(),
 		fileAdapter = await getDefaultFileAdapter(),
+		hasCodeBlocks,
 		namespace,
 		strictLineBreaks,
 		syncMediaAssets,
@@ -107,7 +114,8 @@ export async function mdastToHtml(
 	// Pass breaks setting through to the processor via file data...
 	// saves us from recreating the processor in case the setting changes per-file
 	// (though it basically never should)
-	const hast = await processor.run(mdast, { data: { strictLineBreaks } })
+	const activeProcessor = hasCodeBlocks ? processor : processorWithoutShiki
+	const hast = await activeProcessor.run(mdast, { data: { strictLineBreaks } })
 
 	// Add a wrapper div with a specific class to the HTML, this is hypothetically
 	// useful for styling the output via CSS


### PR DESCRIPTION
## Change Summary

Adds a quick check for fenced code blocks (`markdown.includes('```')`) before parsing markdown, so Shiki is skipped entirely when no code blocks are present, since Shiki parsing carries overhead even when there is nothing to highlight code. See Benchmark Details section for the details.

## Benchmark Details

### Benchmark Scenarios
- Basic cards - create: notes without code, all new notes
- Basic cards - unchanged: notes without code, all existing notes (no content changes)
- Code cards - create: notes with code, all new notes
- Code cards - unchanged: notes with code, all existing notes (no content changes)

10,000 notes for each scenario case.

### Environments

Base Version: 2.0.4
Machine: Apple M4, 32GB RAM, macOS Tahoe 26.3.1

### Overall Results (wall time)

| Scenario | Before | After | Change |
|---|---|---|---|
| Basic cards - create | 4m 16.9s | 4m 14.9s | -0.8% |
| Basic cards - unchanged | 8.5s | 5.5s | **-35%** |
| Code cards - create | 4m 26.8s | 4m 25.4s | -0.5% |
| Code cards - unchanged | 13.9s | 13.0s | -6% |

The measured times were obtained by inserting temporary instrumentation code.

### Phase Breakdown (wall time)

#### Basic cards - create (10,000 notes)

| Phase | Before | After | Change |
|---|---|---|---|
| glob | 76ms | 76ms | - |
| load-and-parse | 5.06s | 2.72s | **-46%** |
| fetch-remote | 47ms | 47ms | - |
| sync-loop | 4m 10.3s | 4m 10.6s | - |
| delete-pass | 14ms | 15ms | - |
| cleanup | 22ms | 25ms | - |
| media-reconcile | 220ms | 224ms | - |
| frontmatter-write | 773ms | 769ms | - |

#### Basic cards - unchanged (10,000 notes)

| Phase | Before | After | Change |
|---|---|---|---|
| glob | 57ms | 56ms | - |
| load-and-parse | 5.35s | 2.83s | **-47%** |
| fetch-remote | 1.18s | 756ms | - |
| sync-loop | 257ms | 258ms | - |
| delete-pass | 237ms | 246ms | - |
| cleanup | 456ms | 451ms | - |
| media-reconcile | 241ms | 200ms | - |
| frontmatter-write | 1ms | 1ms | - |

#### Code cards - create (10,000 notes)

| Phase | Before | After | Change |
|---|---|---|---|
| glob | 91ms | 90ms | - |
| load-and-parse | 9.94s | 9.75s | - |
| fetch-remote | 47ms | 47ms | - |
| sync-loop | 4m 14.8s | 4m 13.3s | - |
| delete-pass | 19ms | 19ms | - |
| cleanup | 22ms | 23ms | - |
| media-reconcile | 752ms | 700ms | - |
| frontmatter-write | 723ms | 709ms | - |

#### Code cards - unchanged (10,000 notes)

| Phase | Before | After | Change |
|---|---|---|---|
| glob | 59ms | 56ms | - |
| load-and-parse | 10.26s | 10.05s | - |
| fetch-remote | 1.23s | 475ms | - |
| sync-loop | 274ms | 267ms | - |
| delete-pass | 232ms | 249ms | - |
| cleanup | 466ms | 446ms | - |
| media-reconcile | 710ms | 729ms | - |
| frontmatter-write | 2ms | 2ms | - |

### load-and-parse Breakdown (cumulative across 10k parallel tasks)

#### Basic cards - create

| Sub-phase | Before | After | Change |
|---|---|---|---|
| readFile | 14,998s | 14,544s | - |
| getNoteFromMarkdown | 35,510s | 2,557ms | **-99.99%** |
| - ast (getAstFromMarkdown) | 1,552ms | 1,530ms | - |
| - html (mdastToHtml) | 35,465s | 430ms | **-99.99%** |
| -- processor.run | 34,153s | 194ms | **-99.99%** |
| -- media visit | 73ms | 67ms | - |
| -- stringify | 68ms | 77ms | - |

#### Basic cards - unchanged

| Sub-phase | Before | After | Change |
|---|---|---|---|
| readFile | 15,562s | 15,045s | - |
| getNoteFromMarkdown | 37,835s | 2,666ms | **-99.99%** |
| - ast (getAstFromMarkdown) | 1,602ms | 1,591ms | - |
| - html (mdastToHtml) | 37,729s | 439ms | **-99.99%** |
| -- processor.run | 36,107s | 201ms | **-99.99%** |
| -- media visit | 78ms | 68ms | - |
| -- stringify | 79ms | 79ms | - |

#### Code cards - create

| Sub-phase | Before | After | Change |
|---|---|---|---|
| readFile | 16,287s | 16,032s | - |
| getNoteFromMarkdown | 83,001s | 81,324s | - |
| - ast (getAstFromMarkdown) | 1,680ms | 1,680ms | - |
| - html (mdastToHtml) | 82,952s | 81,272s | - |
| -- processor.run | 79,440s | 77,758s | - |
| -- media visit | 313ms | 311ms | - |
| -- stringify | 204ms | 212ms | - |

#### Code cards - unchanged

| Sub-phase | Before | After | Change |
|---|---|---|---|
| readFile | 16,029s | 16,139s | - |
| getNoteFromMarkdown | 86,431s | 84,181s | - |
| - ast (getAstFromMarkdown) | 1,730ms | 1,679ms | - |
| - html (mdastToHtml) | 86,375s | 84,124s | - |
| -- processor.run | 82,752s | 80,586s | - |
| -- media visit | 324ms | 314ms | - |
| -- stringify | 218ms | 212ms | - |