### PR TITLE
Fix silently dropped default port in AnkiConnect host validation

### DIFF
--- a/src/bin/utilities/validation.ts
+++ b/src/bin/utilities/validation.ts
@@ -11,7 +11,10 @@ import { urlToHostAndPort } from '../../lib/utilities/url'
 export function urlToHostAndPortValidated(url: string): { host: string; port: number } {
 	const parsedUrl = urlToHostAndPort(url)
 
-	if (parsedUrl === undefined) {
+	// A NaN port means the protocol has no known default port (e.g. the
+	// protocol was omitted entirely, so the host was parsed as a protocol),
+	// which would otherwise produce a broken `host:NaN` request URL downstream.
+	if (parsedUrl === undefined || Number.isNaN(parsedUrl.port)) {
 		throw new Error(`Invalid AnkiConnect URL: "${url}"`)
 	}
 

--- a/src/lib/utilities/url.ts
+++ b/src/lib/utilities/url.ts
@@ -293,10 +293,14 @@ export async function getUrlContentHash(
 
 // The WHATWG URL parser leaves `URL.port` empty when the port matches the
 // protocol's default, so an explicitly-typed default port (e.g. `:443` on
-// https) is otherwise silently dropped.
+// https) is otherwise silently dropped. Covers all "special schemes" with a
+// default port: https://url.spec.whatwg.org/#special-scheme
 const DEFAULT_PORT_BY_PROTOCOL: Record<string, number> = {
+	'ftp:': 21,
 	'http:': 80,
 	'https:': 443,
+	'ws:': 80,
+	'wss:': 443,
 }
 
 export function urlToHostAndPort(url: string): undefined | { host: string; port: number } {
@@ -312,7 +316,7 @@ export function urlToHostAndPort(url: string): undefined | { host: string; port:
 		// yield NaN, preserving the prior behavior for those.
 		port:
 			parsedUrl.port === ''
-				? (DEFAULT_PORT_BY_PROTOCOL[parsedUrl.protocol] ?? Number.NaN)
+				? (DEFAULT_PORT_BY_PROTOCOL[parsedUrl.protocol] ?? NaN)
 				: Number(parsedUrl.port),
 	}
 }

--- a/src/lib/utilities/url.ts
+++ b/src/lib/utilities/url.ts
@@ -291,15 +291,30 @@ export async function getUrlContentHash(
 	return getHash(url, 16)
 }
 
+// The WHATWG URL parser leaves `URL.port` empty when the port matches the
+// protocol's default, so an explicitly-typed default port (e.g. `:443` on
+// https) is otherwise silently dropped.
+const DEFAULT_PORT_BY_PROTOCOL: Record<string, number> = {
+	'http:': 80,
+	'https:': 443,
+}
+
 export function urlToHostAndPort(url: string): undefined | { host: string; port: number } {
 	const parsedUrl = safeParseUrl(url)
-	return parsedUrl === undefined
-		? undefined
-		: {
-				host: `${parsedUrl.protocol}//${parsedUrl.hostname}`,
-				// eslint-disable-next-line unicorn/prefer-number-coercion -- URL port may be an empty string, which must yield NaN here, but Number('') is 0
-				port: Number.parseInt(parsedUrl.port, 10),
-			}
+	if (parsedUrl === undefined) {
+		return undefined
+	}
+
+	return {
+		host: `${parsedUrl.protocol}//${parsedUrl.hostname}`,
+		// `URL.port` is empty for the protocol's default port, so recover it from
+		// the protocol rather than dropping it. Protocols without a known default
+		// yield NaN, preserving the prior behavior for those.
+		port:
+			parsedUrl.port === ''
+				? (DEFAULT_PORT_BY_PROTOCOL[parsedUrl.protocol] ?? Number.NaN)
+				: Number(parsedUrl.port),
+	}
 }
 
 export function hostAndPortToUrl(host: string, port: number): string {

--- a/test/utilities.url.test.ts
+++ b/test/utilities.url.test.ts
@@ -49,6 +49,13 @@ it('recovers a protocol default port that the URL parser drops', () => {
 		host: 'https://ankiconnect.example.com',
 		port: 443,
 	})
+	expect(urlToHostAndPort('http://localhost')).toStrictEqual({
+		host: 'http://localhost',
+		port: 80,
+	})
+
+	// Protocols without a known default port still yield NaN.
+	expect(urlToHostAndPort('gopher://example.com')?.port).toBeNaN()
 
 	const roundTrip = urlToHostAndPort('https://ankiconnect.example.com:443')!
 	expect(hostAndPortToUrl(roundTrip.host, roundTrip.port)).toBe(

--- a/test/utilities.url.test.ts
+++ b/test/utilities.url.test.ts
@@ -32,6 +32,30 @@ it('converts from url to host and port and back', () => {
 	expect(url).toBe('http://localhost:8765')
 })
 
+it('recovers a protocol default port that the URL parser drops', () => {
+	// The WHATWG URL parser normalizes away default ports, so an explicit
+	// `:443`/`:80` must still round-trip rather than becoming NaN.
+	expect(urlToHostAndPort('https://ankiconnect.example.com:443')).toStrictEqual({
+		host: 'https://ankiconnect.example.com',
+		port: 443,
+	})
+	expect(urlToHostAndPort('http://localhost:80')).toStrictEqual({
+		host: 'http://localhost',
+		port: 80,
+	})
+
+	// The same defaults apply when no port is given at all.
+	expect(urlToHostAndPort('https://ankiconnect.example.com')).toStrictEqual({
+		host: 'https://ankiconnect.example.com',
+		port: 443,
+	})
+
+	const roundTrip = urlToHostAndPort('https://ankiconnect.example.com:443')!
+	expect(hostAndPortToUrl(roundTrip.host, roundTrip.port)).toBe(
+		'https://ankiconnect.example.com:443',
+	)
+})
+
 it('detects URLs correctly', () => {
 	// Unsupported Windows paths will throw warnings
 	const spyWarn = vi.spyOn(console, 'warn').mockReturnValue()

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -19,6 +19,12 @@ it('parses an https URL with explicit port', () => {
 	expect(result.port).toBe(8443)
 })
 
+it('parses an https URL with an implicit default port', () => {
+	const result = urlToHostAndPortValidated('https://example.com:443')
+	expect(result.host).toBe('https://example.com')
+	expect(result.port).toBe(443)
+})
+
 it('throws for an invalid URL', () => {
 	expect(() => urlToHostAndPortValidated('not a url')).toThrowErrorMatchingInlineSnapshot(
 		`[Error: Invalid AnkiConnect URL: "not a url"]`,

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -19,10 +19,25 @@ it('parses an https URL with explicit port', () => {
 	expect(result.port).toBe(8443)
 })
 
-it('parses an https URL with an implicit default port', () => {
+it('parses an https URL with an explicit default port', () => {
 	const result = urlToHostAndPortValidated('https://example.com:443')
 	expect(result.host).toBe('https://example.com')
 	expect(result.port).toBe(443)
+})
+
+it('parses an https URL with an implicit default port', () => {
+	const result = urlToHostAndPortValidated('https://example.com')
+	expect(result.host).toBe('https://example.com')
+	expect(result.port).toBe(443)
+})
+
+it('throws for a URL without a resolvable port', () => {
+	// Without a protocol, the URL parser treats `example.com:` as the protocol,
+	// which has no default port. This must fail validation rather than yielding
+	// a NaN port that breaks the AnkiConnect request URL downstream.
+	expect(() => urlToHostAndPortValidated('example.com:8765')).toThrowErrorMatchingInlineSnapshot(
+		`[Error: Invalid AnkiConnect URL: "example.com:8765"]`,
+	)
 })
 
 it('throws for an invalid URL', () => {


### PR DESCRIPTION
`urlToHostAndPort` read `URL.port` directly, but the WHATWG URL parser normalizes away a protocol's default port (443 for https, 80 for http). So `https://host:443` yielded `port: NaN`, which reconstructed as `https://host:NaN` and broke the connection.

Recover the default port from the protocol when `URL.port` is empty. Non-default ports are unchanged, and protocols without a known default still yield NaN as before. Add tests covering the default-port cases.